### PR TITLE
Add subscriptionCount and subscribedSLAs getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ allSLAs()
 *Returns all SLAs*
 
 ```
+subscriptionCount(address _user)
+```
+* Returns the amount of SLAs the user is subscribed to
+
+```
+subscribedSLAs(address _user)
+```
+* Returns all SLAs the user is subscribed to
+
+```
 SLACount()
 ```
 *Returns total amount of SLAs*

--- a/contracts/SLARegistry.sol
+++ b/contracts/SLARegistry.sol
@@ -153,6 +153,40 @@ contract SLARegistry {
     }
 
     /**
+     * @dev public view function that returns the service level agreements the
+     * user is subscribed to
+     */
+    function subscribedSLAs(address _user) public view returns(SLA[] memory) {
+        SLA[] memory SLAList = new SLA[](subscriptionCount(_user));
+        uint SLAListIndex = 0;
+
+        for(uint i = 0; i < SLAs.length; i++) {
+            if (SLAs[i].isSubscribed(_user)) {
+                SLAList[SLAListIndex] = (SLAs[i]);
+                SLAListIndex = SLAListIndex.add(1);
+            }
+        }
+
+        return(SLAList);
+    }
+
+    /**
+     * @dev public view function that returns the amount of SLA's the user is
+     * subscribed to
+     */
+    function subscriptionCount(address _user) public view returns(uint) {
+        uint count = 0;
+
+        for(uint i = 0; i < SLAs.length; i++) {
+            if (SLAs[i].isSubscribed(_user)) {
+                count = count.add(1);
+            }
+        }
+
+        return(count);
+    }
+
+    /**
      * @dev public view function that returns the total amount of service
      * level agreements
      */


### PR DESCRIPTION
Adds `subscriptionCount(address _user)` getter function to get the amount of SLA's the given address is subscribed to and adds `subscribedSLAs(address _user)` to get the SLA's the user is subscribed to.

**[Demo video](https://stacktical.slack.com/files/UD99GPTRS/FLJP3U73M/subscribed_slas.mp4)**

**[Related issue](https://github.com/Stacktical/stacktical-dsla-contracts/issues/31)**