### PR TITLE
Check contractFinished() implementation

### DIFF
--- a/contracts/SLA.sol
+++ b/contracts/SLA.sol
@@ -169,8 +169,12 @@ contract SLA is Staking {
     ) external {
         require(_amount > 0, "zero staking not allowed.");
         string memory position = _position;
-        bool isContractFinished = contractFinished();
-        require(!isContractFinished, 'finished contract');
+        (, uint256 endOfLastValidPeriod) = _periodRegistry.getPeriodStartAndEnd(
+            periodType,
+            finalPeriodId
+        );
+        require(block.timestamp < endOfLastValidPeriod, "Staking disabled after the last period");
+        require(periodSLIs[finalPeriodId].status == Status.NotVerified, "Last period verfied, staking disabled");
         _stake(_amount, _token, position);
         emit Stake(_token, nextVerifiablePeriod, msg.sender, _amount, position);
         IStakeRegistry stakeRegistry = IStakeRegistry(

--- a/deploy/1_sla_registry_fixture.ts
+++ b/deploy/1_sla_registry_fixture.ts
@@ -30,7 +30,9 @@ module.exports = async ({
   await periodRegistry.mock.isInitializedPeriod.returns(true);
   await periodRegistry.mock.periodIsFinished.returns(true);
   await periodRegistry.mock.isValidPeriod.returns(true);
-  await periodRegistry.mock.getPeriodStartAndEnd.returns(0, 0);
+  const periodStartTimestamp = Math.floor(Date.now() / 1000);
+  const periodEndTimestamp = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // Tomorrow
+  await periodRegistry.mock.getPeriodStartAndEnd.returns(periodStartTimestamp, periodEndTimestamp);
 
   const messengerRegistryArtifact = await deployments.getArtifact(
     CONTRACT_NAMES.MessengerRegistry

--- a/deploy/1_sla_registry_fixture.ts
+++ b/deploy/1_sla_registry_fixture.ts
@@ -1,6 +1,7 @@
 import { DeployOptionsBase } from 'hardhat-deploy/dist/types';
 import { CONTRACT_NAMES, DEPLOYMENT_TAGS } from '../constants';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { currentTimestamp, ONE_DAY } from '../test/helper';
 
 module.exports = async ({
   getNamedAccounts,
@@ -30,9 +31,7 @@ module.exports = async ({
   await periodRegistry.mock.isInitializedPeriod.returns(true);
   await periodRegistry.mock.periodIsFinished.returns(true);
   await periodRegistry.mock.isValidPeriod.returns(true);
-  const periodStartTimestamp = Math.floor(Date.now() / 1000);
-  const periodEndTimestamp = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // Tomorrow
-  await periodRegistry.mock.getPeriodStartAndEnd.returns(periodStartTimestamp, periodEndTimestamp);
+  await periodRegistry.mock.getPeriodStartAndEnd.returns(currentTimestamp, currentTimestamp + ONE_DAY);
 
   const messengerRegistryArtifact = await deployments.getArtifact(
     CONTRACT_NAMES.MessengerRegistry

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,0 +1,20 @@
+import { ethers } from "hardhat";
+
+export const parseUnits = (value: string) => ethers.utils.parseUnits(value.toString());
+
+export const latestBlockNumber = async () => {
+	return await ethers.provider.getBlockNumber();
+};
+
+export const evm_increaseTime = async (seconds: number) => {
+	await ethers.provider.send("evm_increaseTime", [seconds]);
+};
+
+export const evm_mine_blocks = async (n: number) => {
+	for (let i = 0; i < n; i++) {
+		await ethers.provider.send("evm_mine", []);
+	}
+};
+
+export const currentTimestamp = Math.floor(Date.now() / 1000);
+export const ONE_DAY = 60 * 60 * 24;

--- a/test/unit/SLA.test.ts
+++ b/test/unit/SLA.test.ts
@@ -21,6 +21,7 @@ import {
 const { deployMockContract } = waffle;
 import { expect } from '../chai-setup';
 import { fromWei, toWei } from 'web3-utils';
+import { currentTimestamp, evm_increaseTime, ONE_DAY } from '../helper';
 
 const leverage = 10;
 const baseSLAConfig = {
@@ -110,6 +111,12 @@ describe(CONTRACT_NAMES.SLA, function () {
     const { sla, dslaToken } = fixture;
     await expect(sla.stakeTokens(0, dslaToken.address, 'long'))
       .to.be.revertedWith('zero staking not allowed.');
+  })
+  it('should not allow staking after the end of last period', async () => {
+    const { sla, dslaToken } = fixture;
+    await evm_increaseTime(currentTimestamp + ONE_DAY * 3);
+    await expect(sla.stakeTokens(mintAmount, dslaToken.address, 'long'))
+      .to.be.revertedWith('Staking disabled after the last period');
   })
   it('should not let notDeployer withdraw tokens if the contract is not finished', async function () {
     const { sla, dslaToken, details } = fixture;


### PR DESCRIPTION
# Requirements
 - We shouldn't be able to make a withdrawal if the last SLA verification is missing
 - We shouldn't be able to make a deposit if a SLA contract is finished
 - A SLA contract is finished when:
```
block.timestamp >= endOfLastValidPeriod && periodSLIs[finalPeriodId].status != Status.NotVerified
```

# Changelog
TDB