### PR TITLE
Fix periodRegistry shadow

### DIFF
--- a/contracts/SLA.sol
+++ b/contracts/SLA.sol
@@ -30,7 +30,6 @@ contract SLA is Staking {
     string public ipfsHash;
     address public immutable messengerAddress;
     ISLARegistry private _slaRegistry;
-    IPeriodRegistry private immutable _periodRegistry;
     SLORegistry private immutable _sloRegistry;
     uint256 public immutable creationBlockNumber;
     uint128 public immutable initialPeriodId;
@@ -101,7 +100,6 @@ contract SLA is Staking {
         ipfsHash = _ipfsHash;
         messengerAddress = _messengerAddress;
         _slaRegistry = ISLARegistry(msg.sender);
-        _periodRegistry = IPeriodRegistry(_slaRegistry.periodRegistry());
         _sloRegistry = SLORegistry(_slaRegistry.sloRegistry());
         creationBlockNumber = block.number;
         initialPeriodId = _initialPeriodId;

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -18,7 +18,7 @@ contract Staking is Ownable {
     /// @dev StakeRegistry contract
     IStakeRegistry private _stakeRegistry;
     /// @dev SLARegistry contract
-    IPeriodRegistry private immutable _periodRegistry;
+    IPeriodRegistry internal immutable _periodRegistry;
     /// @dev DSLA token address to burn fees
     address private immutable _dslaTokenAddress;
 


### PR DESCRIPTION
Changed visibility of _periodRegistry to `internal` in Staking.sol and removed from SLA.sol.
No shadows found in other smart contracts.