### PR TITLE
Fix Reentrancy vulnerabilities

### DIFF
--- a/contracts/MessengerRegistry.sol
+++ b/contracts/MessengerRegistry.sol
@@ -117,9 +117,8 @@ contract MessengerRegistry is IMessengerRegistry {
         uint256 _messengerId
     ) external {
         Messenger storage storedMessenger = _messengers[_messengerId];
-        IMessenger messenger = IMessenger(storedMessenger.messengerAddress);
         require(
-            msg.sender == messenger.owner(),
+            msg.sender == IMessenger(storedMessenger.messengerAddress).owner(),
             'Can only be modified by the owner'
         );
         storedMessenger.specificationUrl = _specificationUrl;
@@ -141,15 +140,13 @@ contract MessengerRegistry is IMessengerRegistry {
             IMessenger messenger = IMessenger(
                 _messengers[index].messengerAddress
             );
-            uint256 requestsCounter = messenger.requestsCounter();
-            uint256 fulfillsCounter = messenger.fulfillsCounter();
             returnMessengers[index] = Messenger({
                 ownerAddress: _messengers[index].ownerAddress,
                 messengerAddress: _messengers[index].messengerAddress,
                 specificationUrl: _messengers[index].specificationUrl,
                 precision: _messengers[index].precision,
-                requestsCounter: requestsCounter,
-                fulfillsCounter: fulfillsCounter,
+                requestsCounter: messenger.requestsCounter(),
+                fulfillsCounter: messenger.fulfillsCounter(),
                 id: _messengers[index].id
             });
         }

--- a/contracts/PeriodRegistry.sol
+++ b/contracts/PeriodRegistry.sol
@@ -137,10 +137,7 @@ contract PeriodRegistry is IPeriodRegistry, Ownable {
         override
         returns (bool initialized)
     {
-        PeriodDefinition memory periodDefinition = periodDefinitions[
-            _periodType
-        ];
-        initialized = periodDefinition.initialized;
+        initialized = periodDefinitions[_periodType].initialized;
     }
 
     /**
@@ -154,10 +151,7 @@ contract PeriodRegistry is IPeriodRegistry, Ownable {
         override
         returns (bool valid)
     {
-        PeriodDefinition memory periodDefinition = periodDefinitions[
-            _periodType
-        ];
-        valid = periodDefinition.starts.length.sub(1) >= _periodId;
+        valid = periodDefinitions[_periodType].starts.length.sub(1) >= _periodId;
     }
 
     /**

--- a/contracts/SLA.sol
+++ b/contracts/SLA.sol
@@ -49,7 +49,7 @@ contract SLA is Staking {
         uint256 indexed periodId,
         address indexed caller,
         uint256 amount,
-        string position
+        Position position
     );
     event ProviderWithdraw(
         address indexed tokenAddress,
@@ -156,18 +156,17 @@ contract SLA is Staking {
     function stakeTokens(
         uint256 _amount,
         address _token,
-        string calldata _position
+        Position _position
     ) external {
         require(_amount > 0, "zero staking not allowed.");
-        string memory position = _position;
         (, uint256 endOfLastValidPeriod) = _periodRegistry.getPeriodStartAndEnd(
             periodType,
             finalPeriodId
         );
         require(block.timestamp < endOfLastValidPeriod, "Staking disabled after the last period");
         require(periodSLIs[finalPeriodId].status == Status.NotVerified, "Last period verfied, staking disabled");
-        _stake(_amount, _token, position);
-        emit Stake(_token, nextVerifiablePeriod, msg.sender, _amount, position);
+        _stake(_amount, _token, _position);
+        emit Stake(_token, nextVerifiablePeriod, msg.sender, _amount, _position);
         IStakeRegistry stakeRegistry = IStakeRegistry(
             _slaRegistry.stakeRegistry()
         );

--- a/contracts/SLARegistry.sol
+++ b/contracts/SLARegistry.sol
@@ -193,10 +193,9 @@ contract SLARegistry is ISLARegistry, ReentrancyGuard {
     function userSLAs(address _user) public view returns (SLA[] memory) {
         uint256 count = _userToSLAIndexes[_user].length;
         SLA[] memory SLAList = new SLA[](count);
-        uint256[] memory userSLAIndexes = _userToSLAIndexes[_user];
 
         for (uint256 i = 0; i < count; i++) {
-            SLAList[i] = (SLAs[userSLAIndexes[i]]);
+            SLAList[i] = (SLAs[_userToSLAIndexes[_user][i]]);
         }
 
         return (SLAList);

--- a/contracts/SLARegistry.sol
+++ b/contracts/SLARegistry.sol
@@ -3,6 +3,7 @@ pragma solidity 0.6.6;
 pragma experimental ABIEncoderV2;
 
 import '@openzeppelin/contracts/math/SafeMath.sol';
+import '@openzeppelin/contracts/utils/ReentrancyGuard.sol';
 import './SLA.sol';
 import './SLORegistry.sol';
 import './interfaces/IPeriodRegistry.sol';
@@ -11,7 +12,7 @@ import './interfaces/IStakeRegistry.sol';
 import './interfaces/IMessenger.sol';
 import './interfaces/ISLARegistry.sol';
 
-contract SLARegistry is ISLARegistry {
+contract SLARegistry is ISLARegistry, ReentrancyGuard {
     using SafeMath for uint256;
 
     /// @dev SLO registry
@@ -69,7 +70,7 @@ contract SLARegistry is ISLARegistry {
         string memory ipfsHash_,
         bytes32[] memory extraData_,
         uint64 leverage_
-    ) public {
+    ) public nonReentrant {
         bool validPeriod = IPeriodRegistry(_periodRegistry).isValidPeriod(
             periodType_,
             initialPeriodId_

--- a/contracts/SLORegistry.sol
+++ b/contracts/SLORegistry.sol
@@ -82,9 +82,8 @@ contract SLORegistry {
         view
         returns (bool)
     {
-        SLO memory slo = registeredSLO[_slaAddress];
-        SLOType sloType = slo.sloType;
-        uint256 sloValue = slo.sloValue;
+        SLOType sloType = registeredSLO[_slaAddress].sloType;
+        uint256 sloValue = registeredSLO[_slaAddress].sloValue;
 
         if (sloType == SLOType.EqualTo) {
             return _value == sloValue;
@@ -125,32 +124,29 @@ contract SLORegistry {
         address _slaAddress,
         uint256 _precision
     ) public view returns (uint256) {
-        uint256 sliValue = _sli;
-        SLO memory slo = registeredSLO[_slaAddress];
-        SLOType sloType = slo.sloType;
-        uint256 sloValue = slo.sloValue;
-        uint256 precision = _precision;
+        SLOType sloType = registeredSLO[_slaAddress].sloType;
+        uint256 sloValue = registeredSLO[_slaAddress].sloValue;
 
         // Ensures a positive deviation for greater / small comparisions
         // The deviation is the percentage difference between SLI and SLO
         uint256 deviation = (
             _sli >= sloValue ? _sli.sub(sloValue) : sloValue.sub(_sli)
-        ).mul(precision).div(sliValue.add(sloValue).div(2));
+        ).mul(_precision).div(_sli.add(sloValue).div(2));
 
         // Enforces a deviation capped at 25%
-        if (deviation > precision.mul(25).div(100)) {
-            deviation = precision.mul(25).div(100);
+        if (deviation > _precision.mul(25).div(100)) {
+            deviation = _precision.mul(25).div(100);
         }
 
         if (sloType == SLOType.EqualTo) {
             // Fixed deviation for this comparison, the reward percentage fully driven by verification period
-            deviation = precision.mul(1).div(100);
+            deviation = _precision.mul(1).div(100);
             return deviation;
         }
 
         if (sloType == SLOType.NotEqualTo) {
             // Fixed deviation for this comparison, the reward percentage fully driven by verification period
-            deviation = precision.mul(1).div(100);
+            deviation = _precision.mul(1).div(100);
             return deviation;
         }
 

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -18,6 +18,11 @@ contract Staking is Ownable, ReentrancyGuard {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
+    enum Position {
+        LONG,
+        SHORT
+    }
+
     /// @dev StakeRegistry contract
     IStakeRegistry private _stakeRegistry;
     /// @dev SLARegistry contract
@@ -62,17 +67,6 @@ contract Staking is Ownable, ReentrancyGuard {
 
     modifier onlyAllowedToken(address _token) {
         require(isAllowedToken(_token), 'token not allowed');
-        _;
-    }
-
-    modifier onlyAllowedPosition(string memory _position) {
-        require(
-            keccak256(abi.encodePacked(_position)) ==
-                keccak256(abi.encodePacked('long')) ||
-                keccak256(abi.encodePacked(_position)) ==
-                keccak256(abi.encodePacked('short')),
-            'position not allowed'
-        );
         _;
     }
 
@@ -206,11 +200,10 @@ contract Staking is Ownable, ReentrancyGuard {
     function _stake(
         uint256 _amount,
         address _tokenAddress,
-        string memory _position
+        Position _position
     )
         internal
         onlyAllowedToken(_tokenAddress)
-        onlyAllowedPosition(_position)
         onlyWhitelisted
         nonReentrant
     {
@@ -222,10 +215,7 @@ contract Staking is Ownable, ReentrancyGuard {
 
         // DSLA-SP proofs of SLA Position
         // string memory short = 'short';
-        if (
-            keccak256(abi.encodePacked(_position)) ==
-            keccak256(abi.encodePacked('short'))
-        ) {
+        if (_position == Position.SHORT) {
             (uint256 providerStake, uint256 usersStake) = (
                 providerPool[_tokenAddress],
                 usersPool[_tokenAddress]
@@ -252,10 +242,7 @@ contract Staking is Ownable, ReentrancyGuard {
 
         // DSLA-LP proofs of SLA Position
         // string memory long = 'long';
-        if (
-            keccak256(abi.encodePacked(_position)) ==
-            keccak256(abi.encodePacked('long'))
-        ) {
+        if (_position == Position.LONG) {
             providerPool[_tokenAddress] = providerPool[_tokenAddress].add(
                 _amount
             );

--- a/contracts/dToken.sol
+++ b/contracts/dToken.sol
@@ -5,7 +5,11 @@ pragma experimental ABIEncoderV2;
 import '@openzeppelin/contracts/presets/ERC20PresetMinterPauser.sol';
 
 contract dToken is ERC20PresetMinterPauser {
-    constructor(string memory name, string memory symbol, uint8 decimals) public ERC20PresetMinterPauser(name, symbol) {
+    constructor(
+        string memory name,
+        string memory symbol,
+        uint8 decimals
+    ) public ERC20PresetMinterPauser(name, symbol) {
         _setupDecimals(decimals);
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
 

--- a/contracts/interfaces/IERC20Query.sol
+++ b/contracts/interfaces/IERC20Query.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.6;
+
+interface IERC20Query {
+    function totalSupply() external view returns (uint256);
+    function decimals() external view returns (uint8);
+    function symbol() external view returns (string memory);
+    function name() external view returns (string memory);
+    function balanceOf(address account) external view returns (uint256);
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    function approve(address spender, uint256 amount) external returns (bool);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/test/unit/SLA.test.ts
+++ b/test/unit/SLA.test.ts
@@ -23,6 +23,10 @@ import { expect } from '../chai-setup';
 import { fromWei, toWei } from 'web3-utils';
 import { currentTimestamp, evm_increaseTime, ONE_DAY } from '../helper';
 
+enum POSITION {
+  LONG,
+  SHORT,
+}
 const leverage = 10;
 const baseSLAConfig = {
   sloValue: 50 * 10 ** 3,
@@ -111,19 +115,19 @@ describe(CONTRACT_NAMES.SLA, function () {
 
   it('should not allow staking 0 amount', async () => {
     const { sla, dslaToken } = fixture;
-    await expect(sla.stakeTokens(0, dslaToken.address, 'long'))
+    await expect(sla.stakeTokens(0, dslaToken.address, POSITION.LONG))
       .to.be.revertedWith('zero staking not allowed.');
   })
   it('should not allow staking after the end of last period', async () => {
     const { sla, dslaToken } = fixture;
     await evm_increaseTime(currentTimestamp + ONE_DAY * 3);
-    await expect(sla.stakeTokens(mintAmount, dslaToken.address, 'long'))
+    await expect(sla.stakeTokens(mintAmount, dslaToken.address, POSITION.LONG))
       .to.be.revertedWith('Staking disabled after the last period');
   })
   it('should not let notDeployer withdraw tokens if the contract is not finished', async function () {
     const { sla, dslaToken, details } = fixture;
     await dslaToken.approve(sla.address, mintAmount);
-    await sla.stakeTokens(mintAmount, dslaToken.address, 'long');
+    await sla.stakeTokens(mintAmount, dslaToken.address, POSITION.LONG);
     const notDeployerSLA = SLA__factory.connect(
       sla.address,
       await ethers.getSigner(notDeployer)
@@ -134,7 +138,7 @@ describe(CONTRACT_NAMES.SLA, function () {
       await ethers.getSigner(notDeployer)
     );
     await notDeployerDSLA.approve(sla.address, mintAmount);
-    await notDeployerSLA.stakeTokens(mintAmount, dslaToken.address, 'long');
+    await notDeployerSLA.stakeTokens(mintAmount, dslaToken.address, POSITION.LONG);
     const duTokenAddress = await sla.duTokenRegistry(dslaToken.address);
     const duToken: ERC20PresetMinterPauser = await ethers.getContractAt(
       'ERC20PresetMinterPauser',
@@ -155,7 +159,7 @@ describe(CONTRACT_NAMES.SLA, function () {
   it('should not let the deployer withdraw provider tokens if the contract is not finished', async () => {
     const { sla, dslaToken, details } = fixture;
     await dslaToken.approve(sla.address, mintAmount);
-    await sla.stakeTokens(mintAmount, dslaToken.address, 'long');
+    await sla.stakeTokens(mintAmount, dslaToken.address, POSITION.LONG);
     const deployerSLA = SLA__factory.connect(
       sla.address,
       await ethers.getSigner(deployer)
@@ -165,7 +169,7 @@ describe(CONTRACT_NAMES.SLA, function () {
       await ethers.getSigner(deployer)
     );
     await deployerDSLA.approve(sla.address, mintAmount);
-    await deployerSLA.stakeTokens(mintAmount, dslaToken.address, 'long');
+    await deployerSLA.stakeTokens(mintAmount, dslaToken.address, POSITION.LONG);
     const duTokenAddress = await sla.dpTokenRegistry(dslaToken.address);
     const duToken: ERC20PresetMinterPauser = await ethers.getContractAt(
       'ERC20PresetMinterPauser',
@@ -188,7 +192,7 @@ describe(CONTRACT_NAMES.SLA, function () {
     const { sla, dslaToken } = fixture;
     let stakeAmount = 100000;
     await dslaToken.approve(sla.address, stakeAmount);
-    await sla.stakeTokens(stakeAmount, dslaToken.address, 'long');
+    await sla.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG);
     await expect(
       sla.withdrawProviderTokens(mintAmount, dslaToken.address)
     ).to.be.revertedWith('not finished');
@@ -199,14 +203,14 @@ describe(CONTRACT_NAMES.SLA, function () {
     const { sla, dslaToken, details } = fixture;
     await dslaToken.approve(sla.address, mintAmount);
     let stakeAmount = 100000;
-    await expect(sla.stakeTokens(stakeAmount, dslaToken.address, 'long'))
+    await expect(sla.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG))
       .to.emit(sla, 'Stake')
       .withArgs(
         dslaToken.address,
         await sla.nextVerifiablePeriod(),
         deployer,
         stakeAmount,
-        "long"
+        POSITION.LONG
       );
     let totalStake = (
       await details.getSLADetailsArrays(sla.address)
@@ -218,7 +222,7 @@ describe(CONTRACT_NAMES.SLA, function () {
     const { sla, dslaToken, details } = fixture;
     await dslaToken.approve(sla.address, mintAmount);
 
-    await expect(sla.stakeTokens(-1000, dslaToken.address, 'long')).to.be
+    await expect(sla.stakeTokens(-1000, dslaToken.address, POSITION.LONG)).to.be
       .reverted;
     let totalStake = (
       await details.getSLADetailsArrays(sla.address)
@@ -230,7 +234,7 @@ describe(CONTRACT_NAMES.SLA, function () {
     const { sla, dslaToken, details } = fixture;
     await dslaToken.approve(sla.address, mintAmount);
     let bigNumber = 10 ** 100000000000000000000000000000000;
-    await expect(sla.stakeTokens(bigNumber, dslaToken.address, 'long')).to.be
+    await expect(sla.stakeTokens(bigNumber, dslaToken.address, POSITION.LONG)).to.be
       .reverted;
 
     let totalStake = (
@@ -278,7 +282,7 @@ describe(CONTRACT_NAMES.SLA, function () {
     const { sla, dslaToken } = fixture;
     await dslaToken.approve(sla.address, mintAmount);
     let stakeAmount = 100000;
-    await sla.stakeTokens(stakeAmount, dslaToken.address, 'long');
+    await sla.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG);
 
     let stakersLength = await sla.getStakersLength();
     expect(stakersLength).to.be.equal(1);
@@ -304,7 +308,7 @@ describe(CONTRACT_NAMES.SLA, function () {
     await notDeployerSLA.stakeTokens(
       amount * leverage,
       dslaToken.address,
-      'long'
+      POSITION.LONG
     );
 
     // provider long stake
@@ -318,7 +322,7 @@ describe(CONTRACT_NAMES.SLA, function () {
     );
 
     await deployerDSLA.approve(sla.address, amount);
-    await deployerSLA.stakeTokens(amount, dslaToken.address, 'short');
+    await deployerSLA.stakeTokens(amount, dslaToken.address, POSITION.SHORT);
 
     // check stakers length
     let stakersLength = await sla.getStakersLength();
@@ -342,7 +346,7 @@ describe(CONTRACT_NAMES.SLA, function () {
     );
 
     await notDeployerDSLA.approve(sla.address, amount);
-    await notDeployerSLA.stakeTokens(amount, dslaToken.address, 'long');
+    await notDeployerSLA.stakeTokens(amount, dslaToken.address, POSITION.LONG);
 
     // provider long stake
     const deployerSLA = SLA__factory.connect(
@@ -355,7 +359,7 @@ describe(CONTRACT_NAMES.SLA, function () {
     );
 
     await deployerDSLA.approve(sla.address, amount);
-    await expect(deployerSLA.stakeTokens(amount, dslaToken.address, 'short')).to
+    await expect(deployerSLA.stakeTokens(amount, dslaToken.address, POSITION.SHORT)).to
       .be.reverted;
   });
 });

--- a/test/unit/StakeRegistry.test.ts
+++ b/test/unit/StakeRegistry.test.ts
@@ -32,6 +32,10 @@ interface SLAConfig {
 	finalPeriodId: number,
 	extraData: BytesLike[]
 }
+enum POSITION {
+	LONG,
+	SHORT,
+}
 const baseSLAConfig = {
 	sloValue: 50 * 10 ** 3,
 	sloType: SLO_TYPE.GreaterThan,
@@ -168,7 +172,7 @@ describe(CONTRACT_NAMES.StakeRegistry, function () {
 		);
 		await sla.addAllowedTokens(dslaToken.address);
 		await dslaToken.approve(slaAddress, mintAmount);
-		await sla.stakeTokens(mintAmount, dslaToken.address, 'long');
+		await sla.stakeTokens(mintAmount, dslaToken.address, POSITION.LONG);
 		expect(await stakeRegistry.slaWasStakedByUser(deployer, slaAddress)).to.be.true;
 		expect(await stakeRegistry.slaWasStakedByUser(deployer, deployer)).to.be.false;
 	})

--- a/test/unit/Staking.test.ts
+++ b/test/unit/Staking.test.ts
@@ -23,6 +23,10 @@ const { deployMockContract } = waffle;
 import { expect } from '../chai-setup';
 import { fromWei, toWei } from 'web3-utils';
 
+enum POSITION {
+  LONG,
+  SHORT,
+}
 const baseSLAConfig = {
   sloValue: 50 * 10 ** 3,
   sloType: SLO_TYPE.GreaterThan,
@@ -156,14 +160,14 @@ describe(CONTRACT_NAMES.Staking, function () {
     await dslaToken.approve(sla.address, mintAmount);
     let stakeAmount = 100000;
 
-    await expect(sla.stakeTokens(stakeAmount, dslaToken.address, 'long'))
+    await expect(sla.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG))
       .to.emit(sla, 'Stake')
       .withArgs(
         dslaToken.address,
         await sla.nextVerifiablePeriod(),
         deployer,
         stakeAmount,
-        'long'
+        POSITION.LONG
       );
     let detailsarrs = (
       await details.getSLADetailsArrays(sla.address)
@@ -198,7 +202,7 @@ describe(CONTRACT_NAMES.Staking, function () {
     await notDeployerSLA.stakeTokens(
       amount * leverage,
       dslaToken.address,
-      'long'
+      POSITION.LONG
     );
 
     // provider long stake
@@ -213,14 +217,14 @@ describe(CONTRACT_NAMES.Staking, function () {
 
 
     await deployerDSLA.approve(sla.address, amount * leverage);
-    await expect(deployerSLA.stakeTokens(amount * leverage, dslaToken.address, 'short'))
+    await expect(deployerSLA.stakeTokens(amount * leverage, dslaToken.address, POSITION.SHORT))
       .to.emit(sla, 'Stake')
       .withArgs(
         dslaToken.address,
         await sla.nextVerifiablePeriod(),
         deployer,
         amount * leverage,
-        'short'
+        POSITION.SHORT
       );
 
     let detailsarrs = (
@@ -238,7 +242,7 @@ describe(CONTRACT_NAMES.Staking, function () {
     await dslaToken.approve(sla.address, mintAmount);
     let stakeAmount = 100000;
 
-    await expect(sla.stakeTokens(stakeAmount, dslaToken.address, 'short'))
+    await expect(sla.stakeTokens(stakeAmount, dslaToken.address, POSITION.SHORT))
       .to.be.revertedWith('user stake')
   });
 
@@ -248,7 +252,7 @@ describe(CONTRACT_NAMES.Staking, function () {
     await dslaToken.approve(sla.address, mintAmount);
     let stakeAmount = 100000000;
 
-    await expect(sla.stakeTokens(stakeAmount, dslaToken.address, 'long'))
+    await expect(sla.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG))
       .to.be.revertedWith('ERC20: transfer amount exceeds allowance')
   });
 
@@ -257,7 +261,7 @@ describe(CONTRACT_NAMES.Staking, function () {
     await dslaToken.approve(sla.address, mintAmount);
     let stakeAmount = 100000;
 
-    await expect(sla.stakeTokens(stakeAmount, dslaToken.address, 'long'))
+    await expect(sla.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG))
       .to.be.revertedWith('token not allowed')
   });
 
@@ -266,7 +270,7 @@ describe(CONTRACT_NAMES.Staking, function () {
     await dslaToken.approve(sla.address, mintAmount);
     let stakeAmount = 100000;
     const invalidTokenAddress = "0x61A12"
-    await expect(sla.stakeTokens(stakeAmount, invalidTokenAddress, 'long'))
+    await expect(sla.stakeTokens(stakeAmount, invalidTokenAddress, POSITION.LONG))
       .to.be.reverted;
   });
 
@@ -318,14 +322,14 @@ describe(CONTRACT_NAMES.Staking, function () {
       await dslaToken.approve(sla.address, mintAmount);
       let stakeAmount = 100000;
 
-      await expect(sla.stakeTokens(stakeAmount, dslaToken.address, 'long'))
+      await expect(sla.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG))
         .to.emit(sla, 'Stake')
         .withArgs(
           dslaToken.address,
           await sla.nextVerifiablePeriod(),
           deployer,
           stakeAmount,
-          'long'
+          POSITION.LONG
         );
       let detailsarrs = (
         await details.getSLADetailsArrays(sla.address)
@@ -344,14 +348,14 @@ describe(CONTRACT_NAMES.Staking, function () {
       await dslaToken.approve(sla_wl.address, mintAmount);
       let stakeAmount = 100000;
 
-      await expect(sla_wl.stakeTokens(stakeAmount, dslaToken.address, 'long'))
+      await expect(sla_wl.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG))
         .to.emit(sla_wl, 'Stake')
         .withArgs(
           dslaToken.address,
           await sla_wl.nextVerifiablePeriod(),
           deployer,
           stakeAmount,
-          'long'
+          POSITION.LONG
         );
       let detailsarrs = (
         await details.getSLADetailsArrays(sla_wl.address)
@@ -379,7 +383,7 @@ describe(CONTRACT_NAMES.Staking, function () {
 
       await notDeployerDSLA.approve(sla_wl.address, stakeAmount);
       await sla_wl.addAllowedTokens(dslaToken.address);
-      await expect(notDeployerSLA.stakeTokens(stakeAmount, dslaToken.address, 'long'))
+      await expect(notDeployerSLA.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG))
         .to.be.revertedWith('not whitelisted');
     });
 
@@ -403,14 +407,14 @@ describe(CONTRACT_NAMES.Staking, function () {
       await sla_wl.addAllowedTokens(dslaToken.address);
       await sla_wl.addUsersToWhitelist([notDeployer])
 
-      await expect(sla_wl.stakeTokens(stakeAmount, dslaToken.address, 'long'))
+      await expect(sla_wl.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG))
         .to.emit(sla_wl, 'Stake')
         .withArgs(
           dslaToken.address,
           await sla_wl.nextVerifiablePeriod(),
           deployer,
           stakeAmount,
-          'long'
+          POSITION.LONG
         );
       let detailsarrs = (
         await details.getSLADetailsArrays(sla_wl.address)
@@ -440,14 +444,14 @@ describe(CONTRACT_NAMES.Staking, function () {
       await sla_wl.addAllowedTokens(dslaToken.address);
       await sla_wl.addUsersToWhitelist([notDeployer])
 
-      await expect(sla_wl.stakeTokens(stakeAmount, dslaToken.address, 'long'))
+      await expect(sla_wl.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG))
         .to.emit(sla_wl, 'Stake')
         .withArgs(
           dslaToken.address,
           await sla_wl.nextVerifiablePeriod(),
           deployer,
           stakeAmount,
-          'long'
+          POSITION.LONG
         );
       let detailsarrs = (
         await details.getSLADetailsArrays(sla_wl.address)
@@ -457,7 +461,7 @@ describe(CONTRACT_NAMES.Staking, function () {
       expect(totalStake).equals(stakeAmount.toString());
 
       await sla_wl.removeUsersFromWhitelist([notDeployer])
-      await expect(notDeployerSLA.stakeTokens(stakeAmount, dslaToken.address, 'long'))
+      await expect(notDeployerSLA.stakeTokens(stakeAmount, dslaToken.address, POSITION.LONG))
         .to.be.revertedWith('not whitelisted');
     });
   });


### PR DESCRIPTION
- Added `nonReentrant` modifier to `_stake`, `_withdrawProviderTokens` and `_withdrawUserTokens` functions in Staking contract and `createSLA` function in SLARegistry contract.
- Updated LONG, SHORT strings to enum to optimize contract size
- Optimized other contracts too 

Note: SLARegistry size is 23.891 KB, almost 1.1KB downsized