### PR TITLE
Messenger precision check

### DIFF
--- a/contracts/MessengerRegistry.sol
+++ b/contracts/MessengerRegistry.sol
@@ -4,12 +4,15 @@ pragma experimental ABIEncoderV2;
 
 import './interfaces/IMessenger.sol';
 import './interfaces/IMessengerRegistry.sol';
+import '@openzeppelin/contracts/math/SafeMath.sol';
 
 /**
  * @title MessengerRegistry
  * @dev MessengerRegistry is a contract to register openly distributed Messengers
  */
 contract MessengerRegistry is IMessengerRegistry {
+    using SafeMath for uint256;
+
     struct Messenger {
         address ownerAddress;
         address messengerAddress;
@@ -89,7 +92,7 @@ contract MessengerRegistry is IMessengerRegistry {
         _ownerMessengers[messengerOwner].push(id);
 
         require(
-            precision % 100 == 0 && precision != 0,
+            precision.mod(100) == 0,
             'invalid messenger precision, cannot register messanger'
         );
 
@@ -126,7 +129,6 @@ contract MessengerRegistry is IMessengerRegistry {
             msg.sender == IMessenger(storedMessenger.messengerAddress).owner(),
             'Can only be modified by the owner'
         );
-
         storedMessenger.specificationUrl = _specificationUrl;
         storedMessenger.ownerAddress = msg.sender;
         emit MessengerModified(

--- a/contracts/MessengerRegistry.sol
+++ b/contracts/MessengerRegistry.sol
@@ -92,7 +92,7 @@ contract MessengerRegistry is IMessengerRegistry {
         _ownerMessengers[messengerOwner].push(id);
 
         require(
-            precision.mod(100) == 0,
+            precision.mod(100) == 0 && precision != 0,
             'invalid messenger precision, cannot register messanger'
         );
 

--- a/contracts/MessengerRegistry.sol
+++ b/contracts/MessengerRegistry.sol
@@ -127,11 +127,6 @@ contract MessengerRegistry is IMessengerRegistry {
             'Can only be modified by the owner'
         );
 
-        require(
-            precision % 100 == 0 && precision != 0,
-            'invalid messenger precision, cannot modify messanger'
-        );
-
         storedMessenger.specificationUrl = _specificationUrl;
         storedMessenger.ownerAddress = msg.sender;
         emit MessengerModified(

--- a/contracts/MessengerRegistry.sol
+++ b/contracts/MessengerRegistry.sol
@@ -88,6 +88,11 @@ contract MessengerRegistry is IMessengerRegistry {
         uint256 id = _messengers.length;
         _ownerMessengers[messengerOwner].push(id);
 
+        require(
+            precision % 100 == 0 || precision != 0,
+            'invalid messenger precision, cannot register messanger'
+        );
+
         _messengers.push(
             Messenger({
                 ownerAddress: messengerOwner,
@@ -121,6 +126,12 @@ contract MessengerRegistry is IMessengerRegistry {
             msg.sender == IMessenger(storedMessenger.messengerAddress).owner(),
             'Can only be modified by the owner'
         );
+
+        require(
+            precision % 100 == 0 || precision != 0,
+            'invalid messenger precision, cannot modify messanger'
+        );
+
         storedMessenger.specificationUrl = _specificationUrl;
         storedMessenger.ownerAddress = msg.sender;
         emit MessengerModified(

--- a/contracts/MessengerRegistry.sol
+++ b/contracts/MessengerRegistry.sol
@@ -89,7 +89,7 @@ contract MessengerRegistry is IMessengerRegistry {
         _ownerMessengers[messengerOwner].push(id);
 
         require(
-            precision % 100 == 0 || precision != 0,
+            precision % 100 == 0 && precision != 0,
             'invalid messenger precision, cannot register messanger'
         );
 
@@ -128,7 +128,7 @@ contract MessengerRegistry is IMessengerRegistry {
         );
 
         require(
-            precision % 100 == 0 || precision != 0,
+            precision % 100 == 0 && precision != 0,
             'invalid messenger precision, cannot modify messanger'
         );
 


### PR DESCRIPTION
This PR adds a simple check that precision is a multiple of 100 when registering a new messenger to DSLA Protocol.