### PR TITLE
issue: dsla-127 : missing validation

### DIFF
--- a/contracts/SLA.sol
+++ b/contracts/SLA.sol
@@ -124,7 +124,7 @@ contract SLA is Staking {
         external
         onlyMessenger
     {
-        require(_periodId >= nextVerifiablePeriod, 'invalid period id');
+        require(_periodId == nextVerifiablePeriod, 'invalid period id');
         emit SLICreated(block.timestamp, _sli, _periodId);
         nextVerifiablePeriod = _periodId + 1;
         PeriodSLI storage periodSLI = periodSLIs[_periodId];

--- a/contracts/SLA.sol
+++ b/contracts/SLA.sol
@@ -124,6 +124,7 @@ contract SLA is Staking {
         external
         onlyMessenger
     {
+        require(_periodId >= nextVerifiablePeriod, 'invalid period id');
         emit SLICreated(block.timestamp, _sli, _periodId);
         nextVerifiablePeriod = _periodId + 1;
         PeriodSLI storage periodSLI = periodSLIs[_periodId];


### PR DESCRIPTION
```
Any _periodId can be passed to the function. Other staking functions
depend on the nextVerifiablePeriod value, which should only grow.


Contract: ./contracts/SLA.sol
Functions: registerSLI
Recommendation: Forbid to pass previous periods.
```
Added `require(_periodId >= nextVerifiablePeriod, 'invalid period id');`
But not sure, if it is possible to request SLI for prev periods.
Also should we only allow SLI requesting only for nextVerifiablePeriod? so `_periodId == nextVerifiablePeriod`?