### PR TITLE
add addressToString to string utils

### DIFF
--- a/contracts/libraries/StringUtils.sol
+++ b/contracts/libraries/StringUtils.sol
@@ -2,6 +2,23 @@
 pragma solidity 0.8.9;
 
 library StringUtils {
+    function addressToString(address _address)
+        internal
+        pure
+        returns (string memory)
+    {
+        bytes32 _bytes = bytes32(uint256(uint160(_address)));
+        bytes memory HEX = '0123456789abcdef';
+        bytes memory _string = new bytes(42);
+        _string[0] = '0';
+        _string[1] = 'x';
+        for (uint256 i = 0; i < 20; i++) {
+            _string[2 + i * 2] = HEX[uint8(_bytes[i + 12] >> 4)];
+            _string[3 + i * 2] = HEX[uint8(_bytes[i + 12] & 0x0f)];
+        }
+        return string(_string);
+    }
+
     function bytes32ToStr(bytes32 _bytes32)
         internal
         pure


### PR DESCRIPTION
My fault, accidently removed `addressToString` function from StringUtils, Added again.