### PR TITLE
Multiplication after division

### DIFF
--- a/contracts/MessengerRegistry.sol
+++ b/contracts/MessengerRegistry.sol
@@ -72,11 +72,11 @@ contract MessengerRegistry is IMessengerRegistry {
         address messengerAddress_,
         string calldata specificationUrl_
     ) external override {
-        require(messengerAddress_ != address(0x0), 'invalid messenger address');
         require(
             msg.sender == _slaRegistry,
             'Should only be called using the SLARegistry contract'
         );
+        require(messengerAddress_ != address(0x0), 'invalid messenger address');
         require(
             !_registeredMessengers[messengerAddress_],
             'messenger already registered'

--- a/contracts/SLA.sol
+++ b/contracts/SLA.sol
@@ -131,18 +131,14 @@ contract SLA is Staking {
         periodSLI.sli = _sli;
         periodSLI.timestamp = block.timestamp;
 
-        uint256 deviation = _sloRegistry.getDeviation(
-            _sli,
-            address(this),
-            10000
-        );
+        uint256 deviation = _sloRegistry.getDeviation(_sli, address(this));
 
         if (_sloRegistry.isRespected(_sli, address(this))) {
             periodSLI.status = Status.Respected;
-            _setProviderReward(_periodId, deviation, 10000);
+            _setProviderReward(_periodId, deviation);
         } else {
             periodSLI.status = Status.NotRespected;
-            _setUserReward(_periodId, deviation, 10000);
+            _setUserReward(_periodId, deviation);
         }
     }
 

--- a/contracts/SLARegistry.sol
+++ b/contracts/SLARegistry.sol
@@ -249,12 +249,12 @@ contract SLARegistry is ISLARegistry, ReentrancyGuard {
         address _messengerAddress,
         string memory _specificationUrl
     ) public nonReentrant {
-        IMessenger(_messengerAddress).setSLARegistry();
         IMessengerRegistry(_messengerRegistry).registerMessenger(
             msg.sender,
             _messengerAddress,
             _specificationUrl
         );
+        IMessenger(_messengerAddress).setSLARegistry();
     }
 
     /**

--- a/contracts/SLARegistry.sol
+++ b/contracts/SLARegistry.sol
@@ -97,7 +97,7 @@ contract SLARegistry is ISLARegistry, ReentrancyGuard {
      * @param leverage_ leverage
      */
     function createSLA(
-        uint256 sloValue_,
+        uint120 sloValue_,
         SLORegistry.SLOType sloType_,
         bool whitelisted_,
         address messengerAddress_,

--- a/contracts/SLORegistry.sol
+++ b/contracts/SLORegistry.sol
@@ -17,7 +17,8 @@ contract SLORegistry {
     }
 
     struct SLO {
-        uint256 sloValue;
+        // half storage slot
+        uint120 sloValue;
         SLOType sloType;
     }
     /**
@@ -61,7 +62,7 @@ contract SLORegistry {
      * @param _slaAddress 3. -
      */
     function registerSLO(
-        uint256 _sloValue,
+        uint120 _sloValue,
         SLOType _sloType,
         address _slaAddress
     ) public onlySLARegistry {

--- a/contracts/SLORegistry.sol
+++ b/contracts/SLORegistry.sol
@@ -25,6 +25,8 @@ contract SLORegistry {
     /// @dev SLO Registered event
     event SLORegistered(address indexed sla, uint256 sloValue, SLOType sloType);
 
+    /// @notice maximum cap of deviation percent = 25%, base 10000
+    uint16 private constant deviationCapPercent = 2500;
     /// @notice address of SLARegistry contract
     address private slaRegistry;
     /// @dev sla address => SLO mapping
@@ -133,19 +135,19 @@ contract SLORegistry {
         ) * _precision) / ((_sli + sloValue) / 2);
 
         // Enforces a deviation capped at 25%
-        if (deviation > _precision / 4) {
-            deviation = _precision / 4;
+        if (deviation > (_precision * deviationCapPercent) / 10000) {
+            deviation = (_precision * deviationCapPercent) / 10000;
         }
 
         if (sloType == SLOType.EqualTo) {
             // Fixed deviation for this comparison, the reward percentage is the cap
-            deviation = _precision / 4;
+            deviation = (_precision * deviationCapPercent) / 10000;
             return deviation;
         }
 
         if (sloType == SLOType.NotEqualTo) {
             // Fixed deviation for this comparison, the reward percentage is the cap
-            deviation = _precision / 4;
+            deviation = (_precision * deviationCapPercent) / 10000;
             return deviation;
         }
 

--- a/contracts/SLORegistry.sol
+++ b/contracts/SLORegistry.sol
@@ -21,15 +21,13 @@ contract SLORegistry {
         uint120 sloValue;
         SLOType sloType;
     }
-    /**
-     * @dev SLO Registered event
-     * @param sla 1. -
-     * @param sloValue 2. -
-     * @param sloType 3. -
-     */
+
+    /// @dev SLO Registered event
     event SLORegistered(address indexed sla, uint256 sloValue, SLOType sloType);
 
+    /// @notice address of SLARegistry contract
     address private slaRegistry;
+    /// @dev sla address => SLO mapping
     mapping(address => SLO) public registeredSLO;
 
     /// @dev Modifier ensuring that certain function can only be called by SLARegistry

--- a/contracts/SLORegistry.sol
+++ b/contracts/SLORegistry.sol
@@ -127,6 +127,7 @@ contract SLORegistry {
     ) external view returns (uint256) {
         SLOType sloType = registeredSLO[_slaAddress].sloType;
         uint256 sloValue = registeredSLO[_slaAddress].sloValue;
+        uint256 cap = (_precision * deviationCapPercent) / 10000;
 
         // Ensures a positive deviation for greater / small comparisons
         // The deviation is the percentage difference between SLI and SLO
@@ -135,20 +136,18 @@ contract SLORegistry {
         ) * _precision) / ((_sli + sloValue) / 2);
 
         // Enforces a deviation capped at 25%
-        if (deviation > (_precision * deviationCapPercent) / 10000) {
-            deviation = (_precision * deviationCapPercent) / 10000;
+        if (deviation > cap) {
+            deviation = cap;
         }
 
         if (sloType == SLOType.EqualTo) {
             // Fixed deviation for this comparison, the reward percentage is the cap
-            deviation = (_precision * deviationCapPercent) / 10000;
-            return deviation;
+            return cap;
         }
 
         if (sloType == SLOType.NotEqualTo) {
             // Fixed deviation for this comparison, the reward percentage is the cap
-            deviation = (_precision * deviationCapPercent) / 10000;
-            return deviation;
+            return cap;
         }
 
         if (sloType == SLOType.SmallerThan) {

--- a/contracts/SLORegistry.sol
+++ b/contracts/SLORegistry.sol
@@ -129,9 +129,12 @@ contract SLORegistry {
 
         // Ensures a positive deviation for greater / small comparisons
         // The deviation is the percentage difference between SLI and SLO
+        //                          | sloValue - sli |
+        // formula =>  deviation = -------------------- %
+        //                          (sli + sloValue) / 2
         uint256 deviation = ((
             _sli >= sloValue ? _sli - sloValue : sloValue - _sli
-        ) * 10000) / ((_sli + sloValue) / 2);
+        ) * 20000) / (_sli + sloValue);
 
         // Enforces a deviation capped at 25%
         if (deviation > deviationCapRate) {

--- a/contracts/SLORegistry.sol
+++ b/contracts/SLORegistry.sol
@@ -134,19 +134,19 @@ contract SLORegistry {
         ) * _precision) / ((_sli + sloValue) / 2);
 
         // Enforces a deviation capped at 25%
-        if (deviation > (_precision * 25) / 100) {
-            deviation = (_precision * 25) / 100;
+        if (deviation > _precision / 4) {
+            deviation = _precision / 4;
         }
 
         if (sloType == SLOType.EqualTo) {
             // Fixed deviation for this comparison, the reward percentage is the cap
-            deviation = (_precision * 25) / 100;
+            deviation = _precision / 4;
             return deviation;
         }
 
         if (sloType == SLOType.NotEqualTo) {
             // Fixed deviation for this comparison, the reward percentage is the cap
-            deviation = (_precision * 25) / 100;
+            deviation = _precision / 4;
             return deviation;
         }
 

--- a/contracts/StakeRegistry.sol
+++ b/contracts/StakeRegistry.sol
@@ -320,9 +320,7 @@ contract StakeRegistry is IStakeRegistry, ReentrancyGuard {
             'Period rewards already distributed'
         );
         _lockedValue.verifiedPeriods[_periodId] = true;
-        _lockedValue.lockedValue =
-            _lockedValue.lockedValue -
-            _lockedValue.dslaDepositByPeriod;
+        _lockedValue.lockedValue -= _lockedValue.dslaDepositByPeriod;
         ERC20(_DSLATokenAddress).safeTransfer(
             _verificationRewardReceiver,
             _lockedValue.dslaUserReward

--- a/contracts/StakeRegistry.sol
+++ b/contracts/StakeRegistry.sol
@@ -3,14 +3,12 @@ pragma solidity 0.8.9;
 
 import '@openzeppelin/contracts/access/Ownable.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
-import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import './SLA.sol';
 import './dToken.sol';
 import './interfaces/IMessenger.sol';
 import './interfaces/ISLARegistry.sol';
 import './interfaces/IStakeRegistry.sol';
-import './libraries/StringUtils.sol';
 
 /**
  * @title StakeRegistry
@@ -18,7 +16,7 @@ import './libraries/StringUtils.sol';
  with controlling certain admin privileged parameters
  */
 contract StakeRegistry is IStakeRegistry, ReentrancyGuard {
-    using SafeERC20 for ERC20;
+    using SafeERC20 for IERC20;
 
     struct LockedValue {
         uint256 lockedValue;
@@ -286,7 +284,7 @@ contract StakeRegistry is IStakeRegistry, ReentrancyGuard {
         uint256 _periodIdsLength
     ) external override onlySLARegistry nonReentrant {
         uint256 lockedValue = _dslaDepositByPeriod * _periodIdsLength;
-        ERC20(_DSLATokenAddress).safeTransferFrom(
+        IERC20(_DSLATokenAddress).safeTransferFrom(
             _slaOwner,
             address(this),
             lockedValue
@@ -321,15 +319,15 @@ contract StakeRegistry is IStakeRegistry, ReentrancyGuard {
         );
         _lockedValue.verifiedPeriods[_periodId] = true;
         _lockedValue.lockedValue -= _lockedValue.dslaDepositByPeriod;
-        ERC20(_DSLATokenAddress).safeTransfer(
+        IERC20(_DSLATokenAddress).safeTransfer(
             _verificationRewardReceiver,
             _lockedValue.dslaUserReward
         );
-        ERC20(_DSLATokenAddress).safeTransfer(
+        IERC20(_DSLATokenAddress).safeTransfer(
             owner(),
             _lockedValue.dslaPlatformReward
         );
-        ERC20(_DSLATokenAddress).safeTransfer(
+        IERC20(_DSLATokenAddress).safeTransfer(
             IMessenger(SLA(_sla).messengerAddress()).owner(),
             _lockedValue.dslaMessengerReward
         );
@@ -367,7 +365,7 @@ contract StakeRegistry is IStakeRegistry, ReentrancyGuard {
         uint256 remainingBalance = _lockedValue.lockedValue;
         require(remainingBalance > 0, 'locked value is empty');
         _lockedValue.lockedValue = 0;
-        ERC20(_DSLATokenAddress).safeTransfer(
+        IERC20(_DSLATokenAddress).safeTransfer(
             SLA(_sla).owner(),
             remainingBalance
         );

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -79,7 +79,7 @@ contract Staking is Ownable, ReentrancyGuard {
     /// @dev claiming fees when a user claim tokens, base 10000
     uint16 private constant ownerRewardsRate = 30; // 0.3%, base 10000
     uint16 private constant protocolRewardsRate = 15; // 0.15%, base 10000
-    uint16 private constant rewardsCapRate = 2500;
+    uint16 private constant rewardsCapRate = 2500; // 25%, base 10000
 
     modifier onlyAllowedToken(address _token) {
         require(isAllowedToken(_token), 'This token is not allowed.');
@@ -336,7 +336,9 @@ contract Staking is Ownable, ReentrancyGuard {
                 (leverage * _precision);
 
             // Reward must be less than 25% of usersPool to ensure payout at all time
-            if (reward > usersPool[tokenAddress] / 4) {
+            if (
+                reward > (usersPool[tokenAddress] * rewardsCapRate) / _precision
+            ) {
                 reward =
                     (usersPool[tokenAddress] * _rewardPercentage) /
                     _precision;
@@ -372,7 +374,10 @@ contract Staking is Ownable, ReentrancyGuard {
                 _rewardPercentage) / _precision;
 
             // Compensation must be less than 25% of providersPool to ensure payout at all time
-            if (compensation > providersPool[tokenAddress] / 4) {
+            if (
+                compensation >
+                (providersPool[tokenAddress] * rewardsCapRate) / _precision
+            ) {
                 compensation =
                     (providersPool[tokenAddress] * _rewardPercentage) /
                     _precision;

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -335,11 +335,11 @@ contract Staking is Ownable, ReentrancyGuard {
         for (uint256 index = 0; index < allowedTokens.length; index++) {
             address tokenAddress = allowedTokens[index];
 
-            uint256 reward = ((providersPool[tokenAddress] / leverage) *
-                _rewardPercentage) / _precision;
+            uint256 reward = (providersPool[tokenAddress] * _rewardPercentage) /
+                (leverage * _precision);
 
             // Reward must be less than 25% of usersPool to ensure payout at all time
-            if (reward > (usersPool[tokenAddress] * 25) / 100) {
+            if (reward > usersPool[tokenAddress] / 4) {
                 reward =
                     (usersPool[tokenAddress] * _rewardPercentage) /
                     _precision;
@@ -377,10 +377,9 @@ contract Staking is Ownable, ReentrancyGuard {
                 _rewardPercentage) / _precision;
 
             // Compensation must be less than 25% of providersPool to ensure payout at all time
-            if (compensation > (providersPool[tokenAddress] * 25) / 100) {
+            if (compensation > providersPool[tokenAddress] / 4) {
                 compensation =
-                    providersPool[tokenAddress] *
-                    _rewardPercentage *
+                    (providersPool[tokenAddress] * _rewardPercentage) /
                     _precision;
             }
 

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -79,6 +79,7 @@ contract Staking is Ownable, ReentrancyGuard {
     /// @dev claiming fees when a user claim tokens, base 10000
     uint16 private constant ownerRewardsRate = 30; // 0.3%, base 10000
     uint16 private constant protocolRewardsRate = 15; // 0.15%, base 10000
+    uint16 private constant rewardsCapRate = 2500;
 
     modifier onlyAllowedToken(address _token) {
         require(isAllowedToken(_token), 'This token is not allowed.');
@@ -322,14 +323,12 @@ contract Staking is Ownable, ReentrancyGuard {
     /**
      * @notice Set rewards of provider pool for specific periodId
      * @param _periodId Period ID to set rewards
-     * @param _rewardPercentage Percentage to allocate for rewards
-     * @param _precision Precision of Percentage
+     * @param _rewardPercentage Percentage to allocate for rewards, base 10000
      */
-    function _setProviderReward(
-        uint256 _periodId,
-        uint256 _rewardPercentage,
-        uint256 _precision
-    ) internal {
+    function _setProviderReward(uint256 _periodId, uint256 _rewardPercentage)
+        internal
+    {
+        uint256 _precision = 10000;
         for (uint256 index = 0; index < allowedTokens.length; index++) {
             address tokenAddress = allowedTokens[index];
 
@@ -359,14 +358,12 @@ contract Staking is Ownable, ReentrancyGuard {
     /**
      * @notice Set rewards of user pool for specific periodId
      * @param _periodId Period ID to set rewards
-     * @param _rewardPercentage Percentage to allocate for rewards
-     * @param _precision Precision of Percentage
+     * @param _rewardPercentage Percentage to allocate for rewards, base 10000
      */
-    function _setUserReward(
-        uint256 _periodId,
-        uint256 _rewardPercentage,
-        uint256 _precision
-    ) internal {
+    function _setUserReward(uint256 _periodId, uint256 _rewardPercentage)
+        internal
+    {
+        uint256 _precision = 10000;
         for (uint256 index = 0; index < allowedTokens.length; index++) {
             address tokenAddress = allowedTokens[index];
 

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
 
-import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts/access/Ownable.sol';
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
@@ -10,7 +9,6 @@ import './interfaces/ISLARegistry.sol';
 import './interfaces/IPeriodRegistry.sol';
 import './interfaces/IMessenger.sol';
 import './interfaces/IERC20Query.sol';
-import './libraries/StringUtils.sol';
 import './dToken.sol';
 
 /**

--- a/contracts/interfaces/ISLORegistry.sol
+++ b/contracts/interfaces/ISLORegistry.sol
@@ -2,11 +2,10 @@
 pragma solidity 0.8.9;
 
 interface ISLORegistry {
-    function getDeviation(
-        uint256 _sli,
-        address _slaAddress,
-        uint256 _precision
-    ) external view returns (uint256);
+    function getDeviation(uint256 _sli, address _slaAddress)
+        external
+        view
+        returns (uint256);
 
     function isRespected(uint256 _value, address _slaAddress)
         external

--- a/test/unit/MessengerRegistry.test.ts
+++ b/test/unit/MessengerRegistry.test.ts
@@ -1,9 +1,10 @@
-const hre = require('hardhat');
 import { IMessenger, MessengerRegistry, SLARegistry } from '../../typechain';
-const { ethers, waffle, deployments, getNamedAccounts } = hre;
+import { ethers, waffle, deployments, getNamedAccounts } from 'hardhat';
 import { CONTRACT_NAMES, DEPLOYMENT_TAGS } from '../../constants';
 const { deployMockContract } = waffle;
 import { expect } from '../chai-setup';
+import { MockContract } from 'ethereum-waffle';
+import { ethers as Ethers } from 'ethers';
 
 const setup = deployments.createFixture(async () => {
   await deployments.fixture(DEPLOYMENT_TAGS.DSLA);
@@ -48,8 +49,8 @@ const setup = deployments.createFixture(async () => {
 type Fixture = {
   messengerRegistry: MessengerRegistry;
   slaRegistry: SLARegistry;
-  mockMessenger: IMessenger;
-  mockMessenger2: IMessenger;
+  mockMessenger: MockContract;
+  mockMessenger2: MockContract;
 };
 
 describe(CONTRACT_NAMES.MessengerRegistry, function () {
@@ -88,6 +89,10 @@ describe(CONTRACT_NAMES.MessengerRegistry, function () {
     await expect(
       slaRegistry.registerMessenger(invalidAddress, dummySpecUrl)
     ).to.be.reverted;
+
+    await expect(
+      slaRegistry.registerMessenger(Ethers.constants.AddressZero, dummySpecUrl)
+    ).to.be.revertedWith('invalid messenger address')
   });
 
   it('should modify messengers with valid id and specUrl', async function () {

--- a/test/unit/SLA.test.ts
+++ b/test/unit/SLA.test.ts
@@ -21,7 +21,7 @@ import {
 const { deployMockContract } = waffle;
 import { expect } from '../chai-setup';
 import { fromWei, toWei } from 'web3-utils';
-import { currentTimestamp, evm_increaseTime, ONE_DAY } from '../helper';
+import { ethers as Ethers } from 'ethers';
 
 enum POSITION {
   OK,
@@ -114,6 +114,24 @@ describe(CONTRACT_NAMES.SLA, function () {
     notDeployer = (await getNamedAccounts()).notDeployer;
     fixture = await setup();
   });
+
+  it('should revert creating SLA if owner or messenger address is invalid', async () => {
+    const slaRegistry: SLARegistry = await ethers.getContract(
+      CONTRACT_NAMES.SLARegistry
+    );
+    await expect(slaRegistry.createSLA(
+      baseSLAConfig.sloValue,
+      baseSLAConfig.sloType,
+      baseSLAConfig.whitelisted,
+      Ethers.constants.AddressZero,
+      baseSLAConfig.periodType,
+      baseSLAConfig.initialPeriodId,
+      baseSLAConfig.finalPeriodId,
+      'dummy-ipfs-hash',
+      baseSLAConfig.extraData,
+      baseSLAConfig.leverage
+    )).to.be.revertedWith('invalid messenger address');
+  })
 
   it('should not allow staking 0 amount', async () => {
     const { sla, dslaToken } = fixture;

--- a/test/unit/SLORegistry.test.ts
+++ b/test/unit/SLORegistry.test.ts
@@ -262,8 +262,7 @@ describe(CONTRACT_NAMES.SLORegistry, function () {
 			const sliValue = 45 * 10 ** 3;
 			const deviation = await sloRegistry.getDeviation(
 				sliValue,
-				slaAddress,
-				10000,
+				slaAddress
 			)
 			expect(deviation).to.be.equal(BigNumber.from(1 * 2500));
 		})
@@ -277,8 +276,7 @@ describe(CONTRACT_NAMES.SLORegistry, function () {
 			const sliValue = 45 * 10 ** 3;
 			const deviation = await sloRegistry.getDeviation(
 				sliValue,
-				slaAddress,
-				10000,
+				slaAddress
 			)
 			expect(deviation).to.be.equal(BigNumber.from(1 * 2500));
 		})
@@ -290,14 +288,12 @@ describe(CONTRACT_NAMES.SLORegistry, function () {
 			const sliValue = 45 * 10 ** 3;
 			const deviation = await sloRegistry.getDeviation(
 				sliValue,
-				slaAddress,
-				10000,
+				slaAddress
 			)
 			expect(deviation).to.be.equal(BigNumber.from(getDeviation(sloValue, sliValue, precision)));
 			expect(await sloRegistry.getDeviation(
 				sliValue / 2,
-				slaAddress,
-				10000,
+				slaAddress
 			)).to.be.equal(BigNumber.from(25).mul(precision).div(100));
 		})
 		it("GreaterOrEqualTo", async () => {
@@ -311,14 +307,12 @@ describe(CONTRACT_NAMES.SLORegistry, function () {
 			const sliValue = 45 * 10 ** 3;
 			const deviation = await sloRegistry.getDeviation(
 				sliValue,
-				slaAddress,
-				10000,
+				slaAddress
 			)
 			expect(deviation).to.be.equal(BigNumber.from(getDeviation(sloValue, sliValue, precision)));
 			expect(await sloRegistry.getDeviation(
 				sliValue / 2,
-				slaAddress,
-				10000,
+				slaAddress
 			)).to.be.equal(BigNumber.from(25).mul(precision).div(100));
 		})
 		it("SmallerThan", async () => {
@@ -332,14 +326,12 @@ describe(CONTRACT_NAMES.SLORegistry, function () {
 			const sliValue = 45 * 10 ** 3;
 			const deviation = await sloRegistry.getDeviation(
 				sliValue,
-				slaAddress,
-				10000,
+				slaAddress
 			)
 			expect(deviation).to.be.equal(BigNumber.from(getDeviation(sloValue, sliValue, precision)));
 			expect(await sloRegistry.getDeviation(
 				sliValue / 2,
-				slaAddress,
-				10000,
+				slaAddress
 			)).to.be.equal(BigNumber.from(25).mul(precision).div(100));
 		})
 		it("SmallerOrEqualTo", async () => {
@@ -353,14 +345,12 @@ describe(CONTRACT_NAMES.SLORegistry, function () {
 			const sliValue = 45 * 10 ** 3;
 			const deviation = await sloRegistry.getDeviation(
 				sliValue,
-				slaAddress,
-				10000,
+				slaAddress
 			)
 			expect(deviation).to.be.equal(BigNumber.from(getDeviation(sloValue, sliValue, precision)));
 			expect(await sloRegistry.getDeviation(
 				sliValue / 2,
-				slaAddress,
-				10000,
+				slaAddress
 			)).to.be.equal(BigNumber.from(25).mul(precision).div(100));
 		})
 	})

--- a/test/unit/StakeRegistry.test.ts
+++ b/test/unit/StakeRegistry.test.ts
@@ -138,6 +138,14 @@ describe(CONTRACT_NAMES.StakeRegistry, function () {
 		expect(await stakeRegistry.DSLATokenAddress()).to.be.equal(dslaToken.address);
 		expect(await stakeRegistry.allowedTokens(0)).to.be.equal(dslaToken.address);
 	})
+	it("should revert constructor if DSLA token address is invalid", async () => {
+		const { deploy } = deployments
+		await expect(deploy(CONTRACT_NAMES.StakeRegistry, {
+			from: deployer,
+			log: true,
+			args: [Ethers.constants.AddressZero],
+		})).to.be.revertedWith('invalid DSLA token address');
+	})
 	it("should be able to set slaRegistry address once at first", async () => {
 		const { stakeRegistry, slaRegistry } = fixture;
 		const slaRegistryOnStake = await stakeRegistry.slaRegistry();


### PR DESCRIPTION
This PR updates math operations to do multiplication first before division during the calculations to avoid rounding issues of Solidity math.
```
e.g 25% apply 
_precision * 25 / 100 => _precision / 4
// It is still human-readable and it has a comment to notify it applies 25%

reward = providerPools[tokenAddress] / leverage * _rewardPercentage / _precision
=>
reward = providerPools[tokenAddress] * _rewardPercentage / leverage / _precision
```