### PR TITLE
Change rewardsRate states to constant

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -79,8 +79,8 @@ contract Staking is Ownable, ReentrancyGuard {
     uint64 public immutable leverage;
 
     /// @dev claiming fees when a user claim tokens, base 10000
-    uint256 private constant ownerRewardsRate = 30; // 0.3%, base 10000
-    uint256 private constant protocolRewardsRate = 15; // 0.15%, base 10000
+    uint16 private constant ownerRewardsRate = 30; // 0.3%, base 10000
+    uint16 private constant protocolRewardsRate = 15; // 0.15%, base 10000
 
     /// @dev periodId=>providerReward mapping
     mapping(uint256 => uint256) public providerRewards;

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -78,9 +78,9 @@ contract Staking is Ownable, ReentrancyGuard {
 
     uint64 public immutable leverage;
 
-    /// @dev claiming fees when a user claim tokens, should by divided by 10000
-    uint256 private ownerRewardsRate = 30; // 0.3%
-    uint256 private protocolRewardsRate = 15; // 0.15%
+    /// @dev claiming fees when a user claim tokens, base 10000
+    uint256 private constant ownerRewardsRate = 30; // 0.3%, base 10000
+    uint256 private constant protocolRewardsRate = 15; // 0.15%, base 10000
 
     /// @dev periodId=>providerReward mapping
     mapping(uint256 => uint256) public providerRewards;


### PR DESCRIPTION
`ownerRewardRate` and `protocolRewardRate` in staking contracts are never changes.
Declared them constant to save gas fees.