### PR TITLE
Add stringFloatToUnit function to StringUtils library

### DIFF
--- a/contracts/libraries/StringUtils.sol
+++ b/contracts/libraries/StringUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.9;
+pragma solidity ^0.8.9;
 
 library StringUtils {
     function addressToString(address _address)
@@ -69,5 +69,53 @@ library StringUtils {
             value /= 10;
         }
         return string(buffer);
+    }
+
+    function stringFloatToUnit(bytes memory value)
+        internal
+        pure
+        returns (uint256 result)
+    {
+        uint256 i;
+        uint256 counterBeforeDot;
+        uint256 counterAfterDot;
+        result = 0;
+        uint256 totNum = value.length;
+        totNum--;
+        bool hasDot = false;
+
+        for (i = 0; i < value.length; i++) {
+            uint8 c = uint8(value[i]);
+
+            if (c >= 48 && c <= 57) {
+                result = result * 10 + (c - 48);
+                counterBeforeDot++;
+                totNum--;
+            }
+
+            if (c == 46) {
+                hasDot = true;
+                break;
+            }
+        }
+
+        if (hasDot) {
+            for (uint256 j = 0; j < 18; j++) {
+                uint8 m = uint8(value[counterBeforeDot + 1 + j]);
+                if (m >= 48 && m <= 57) {
+                    result = result * 10 + (m - 48);
+                    counterAfterDot++;
+                    totNum--;
+                }
+
+                if (totNum == 0) {
+                    break;
+                }
+            }
+        }
+        if (counterAfterDot <= 18) {
+            uint256 addNum = 18 - counterAfterDot;
+            result = result * 10**addNum;
+        }
     }
 }

--- a/contracts/mocks/MockStringUtils.sol
+++ b/contracts/mocks/MockStringUtils.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.9;
+
+import '../libraries/StringUtils.sol';
+
+contract MockStringUtils {
+    function stringFloatToUnit(bytes memory value)
+        external
+        pure
+        returns (uint256)
+    {
+        return StringUtils.stringFloatToUnit(value);
+    }
+}

--- a/test/unit/StringUtils.test.ts
+++ b/test/unit/StringUtils.test.ts
@@ -1,0 +1,26 @@
+import { expect } from "chai";
+import { utils } from "ethers";
+import { ethers } from "hardhat";
+import { CONTRACT_NAMES } from "../../constants";
+import { MockStringUtils } from "../../typechain";
+
+describe(CONTRACT_NAMES.StringUtils, () => {
+	let stringUtils: MockStringUtils;
+	before(async () => {
+		const MockStringUtils = await ethers.getContractFactory("MockStringUtils");
+		stringUtils = <MockStringUtils>await MockStringUtils.deploy();
+		await stringUtils.deployed();
+	})
+	describe("stringFloatToUnit", () => {
+		it("should return unit from bytes that has less than 18 precision", async () => {
+			const value = 3.14159265359
+			const uint = await stringUtils.stringFloatToUnit(utils.formatBytes32String(value.toString()));
+			expect(utils.formatUnits(uint, 18)).to.be.equal(value.toString());
+		})
+		it("should cut decimals if it has 18+ decimals", async () => {
+			const value = 3.1415926535897932384626 // 22 decimals
+			const uint = await stringUtils.stringFloatToUnit(utils.formatBytes32String(value.toString()));
+			expect(utils.formatUnits(uint, 18)).to.be.equal('3.141592653589793');
+		})
+	})
+})


### PR DESCRIPTION
# Why
TruFlation Chainlink Oracles are returning inflation rates of float in bytes32 format, e.g "8.826584196640917"
This new `stringFloatToUnit` function will be used in DTK messengers to convert above bytes float to unit.

# Changes
## StringUtils.sol
Added `stringFloatToUnit` function which converts float bytes32 to 1e18 based unit256.

## MockStringUtils.sol
Mock contract that just calls the function in string utils, which will be used in unit test only.

## StringUtils.test.ts
Added unit tests of `stringFloatToUnit` function